### PR TITLE
Disallow nan values for metrics

### DIFF
--- a/Metric.js
+++ b/Metric.js
@@ -206,8 +206,10 @@ class Metric {
         // Validate required fields
         if (this.data && this.data.constructor.name === 'Bitmask') {
             this.data.validate();
-        } else if (!['number', 'boolean'].includes(typeof this.data) && !isHex(this.data) || Number.isNaN(this.data)) {
+        } else if (!['number', 'boolean'].includes(typeof this.data) && !isHex(this.data)) {
             throw new Error('A Bitmask, Number, Hex String, or Boolean value for field `data` is required');
+        } else if (Number.isNaN(this.data)) {
+            throw new Error('Field `data` may not be NaN');
         }
 
         if (typeof this.metric !== 'string') {

--- a/Metric.js
+++ b/Metric.js
@@ -206,7 +206,7 @@ class Metric {
         // Validate required fields
         if (this.data && this.data.constructor.name === 'Bitmask') {
             this.data.validate();
-        } else if (!['number', 'boolean'].includes(typeof this.data) && !isHex(this.data)) {
+        } else if (!['number', 'boolean'].includes(typeof this.data) && !isHex(this.data) || Number.isNaN(this.data)) {
             throw new Error('A Bitmask, Number, Hex String, or Boolean value for field `data` is required');
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@moogsoft/mars-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/Metric.test.js
+++ b/test/Metric.test.js
@@ -65,7 +65,7 @@ describe('Validation Method', () => {
             .setSource('localhost')
             .setData(NaN);
 
-        expect(() => invalidMetric.validate()).toThrow('A Bitmask, Number, Hex String, or Boolean value for field `data` is required');
+        expect(() => invalidMetric.validate()).toThrow('Field `data` may not be NaN');
     });
 
     it('validate: missing metric name', () => {

--- a/test/Metric.test.js
+++ b/test/Metric.test.js
@@ -59,6 +59,15 @@ describe('Validation Method', () => {
         expect(() => invalidMetric.validate()).toThrow('A Bitmask, Number, Hex String, or Boolean value for field `data` is required');
     });
 
+    it('validate: NaN value', () => {
+        const invalidMetric = new Metric()
+            .setMetric('valid.metric.1')
+            .setSource('localhost')
+            .setData(NaN);
+
+        expect(() => invalidMetric.validate()).toThrow('A Bitmask, Number, Hex String, or Boolean value for field `data` is required');
+    });
+
     it('validate: missing metric name', () => {
         const invalidMetric = new Metric()
             .setSource('localhost')


### PR DESCRIPTION
Turns out `typeof NaN` is 'number', we should disallow NaN values for metrics. 