### PR TITLE
Config file read

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 const { execSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const hjson = require('hjson');
 
 const constants = fs.constants || fs;
 
@@ -186,7 +187,8 @@ function isHex(input) {
 /**
  * Gets the config sent from the collector and parses it as JSON
  */
-function getConfig() {
+
+function getConfig(configFile) {
     if (MOOG_CREDS_AND_CONFIG === null) {
         // eslint-disable-next-line no-underscore-dangle
         if (process.stdin._readableState.highWaterMark > 0) {
@@ -203,7 +205,44 @@ function getConfig() {
         || !MOOG_CREDS_AND_CONFIG.config
         || !(typeof MOOG_CREDS_AND_CONFIG.config === 'object')
     ) {
-        return {};
+        // Check to see if there is a local config file we can
+        // parse and send.
+        // Config directory is fixed as $MOOGSOFT_HOME/collector/config
+
+        if (!configFile) {
+            info('No config file specified, no config file check will be done');
+            return {};
+        }
+
+        if (!process.env.MOOGSOFT_HOME) {
+            warn('MOOGSOFT_HOME environment variable not set, unable to determine config');
+            return {};
+        }
+
+        const configFileName = `${process.env.MOOGSOFT_HOME}/collector/config/${configFile}`;
+
+        try {
+            fs.accessSync(configFileName, fs.constants.R_OK);
+        } catch (existError) {
+            warn(`Could not find config file: ${configFileName} : ${existError.message} `);
+            return {};
+        }
+
+        let configFileContents;
+        try {
+            configFileContents = fs.readFileSync(configFileName, 'utf8');
+        } catch (readError) {
+            warn(`Could not read config file: ${configFileName} : ${readError.message} `);
+            return {};
+        }
+
+        try {
+            const configJson = hjson.parse(configFileContents);
+            return configJson;
+        } catch (parseError) {
+            warn(`Could not parse config file: ${configFileName} : ${parseError.message} `);
+            return {};
+        }
     }
     return MOOG_CREDS_AND_CONFIG.config;
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test-console": "^1.1.0"
     },
     "dependencies": {
-        "hsjon" : "3.2.2"
+        "hjson" : "3.2.2"
     },
     "directories": {
         "test": "test"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
         "jest": "^26.6.1",
         "test-console": "^1.1.0"
     },
-    "dependencies": {},
+    "dependencies": {
+        "hsjon" : "3.2.2"
+    },
     "directories": {
         "test": "test"
     }


### PR DESCRIPTION
Allows a getConfig to be passed a filename to read if no API delivered config was present. 